### PR TITLE
Make sure that the current page number is always an integer

### DIFF
--- a/src/Porpaginas/Pager.php
+++ b/src/Porpaginas/Pager.php
@@ -13,7 +13,7 @@ final class Pager implements \IteratorAggregate
     {
         $this->totalCount = $page->totalCount();
         $this->limit = $page->getCurrentLimit();
-        $this->currentPageNumber = max(1, $page->getCurrentPage());
+        $this->currentPageNumber = intval(max(1, $page->getCurrentPage()));
         $this->page = $page;
     }
 


### PR DESCRIPTION
Sometimes, `Porpaginas\Page::getCurrentPage()` returns a float, which messes with the behavior of `Porpaginas\Page::isCurrent()` and prevents the correct detection of current page.